### PR TITLE
Smallest/largest deletion

### DIFF
--- a/src/main/java/com/example/pokedex/OrderedDictionary.java
+++ b/src/main/java/com/example/pokedex/OrderedDictionary.java
@@ -19,8 +19,11 @@ public class OrderedDictionary {
     private TreeNode root;
 
     private TreeNode smallest = null;
+    private int smallInd = 0;
 
     private TreeNode largest = null;
+
+    private int largeInd = 0;
 
     public ObjectRecord find(DataKey k) {
         return find(root, k);
@@ -74,6 +77,8 @@ public class OrderedDictionary {
 
     public void remove(DataKey k) {
         root = remove(root, k);
+
+        // Update smallest or largest if deleted
         if (k.compareTo(smallest.data.key) == 0){
             TreeNode node = getNodeByIndex(0);
             smallest = node;
@@ -84,7 +89,6 @@ public class OrderedDictionary {
             largest = node;
             findLargest();
         }
-        // Ensure smallest or largest was not deleted
     }
 
     private void findSmallest(){
@@ -93,7 +97,6 @@ public class OrderedDictionary {
 
     private void findSmallest(TreeNode node){
         if (node.data.key.height < smallest.data.key.height) {
-            //System.out.println(node.data.key.name);
             smallest = node;
         }
         if (node.right != null) { findSmallest(node.right); }
@@ -104,7 +107,6 @@ public class OrderedDictionary {
 
     private void findLargest(TreeNode node){
         if (node.data.key.height > largest.data.key.height) {
-            //System.out.println(node.data.key.name);
             largest = node;
         }
         if (node.right != null) { findLargest(node.right); }
@@ -203,10 +205,12 @@ public class OrderedDictionary {
     }
 
     public int getSmallestIndex(){
-        return (largest == null) ? null : smallest.leftSubtreeSize;
+        //nonfunctioning
+        return (smallest == null) ? null : findNode(smallest.data.key).leftSubtreeSize;
     }
     public int getLargestIndex(){
-        return (largest == null) ? null : largest.leftSubtreeSize;
+        //nonfunctioning
+        return (largest == null) ? null : findNode(largest.data.key).leftSubtreeSize;
     }
 
     public int size() {

--- a/src/main/java/com/example/pokedex/OrderedDictionary.java
+++ b/src/main/java/com/example/pokedex/OrderedDictionary.java
@@ -171,6 +171,9 @@ public class OrderedDictionary {
         size = 0;
     }
 
+    public ObjectRecord smallest(){ return getByIndex(0); }
+    public ObjectRecord largest(){ return getByIndex(size - 1); }
+    public Boolean isEmpty(){ return (size == 0); } // or root == null
 
     public ObjectRecord getByIndex(int index) {
         return getByIndex(root, index);

--- a/src/main/java/com/example/pokedex/OrderedDictionary.java
+++ b/src/main/java/com/example/pokedex/OrderedDictionary.java
@@ -34,6 +34,17 @@ public class OrderedDictionary {
         else return find(node.right, k);
     }
 
+    private TreeNode findNode(DataKey k) {
+        return findNode(root, k);
+    }
+    private TreeNode findNode(TreeNode node, DataKey k) {
+        if (node == null) return null;
+
+        if (k.compareTo(node.data.key) == 0) return node;
+        if (k.compareTo(node.data.key) < 0) return findNode(node.left, k);
+        else return findNode(node.right, k);
+    }
+
     public void insert(ObjectRecord r) {
         root = insert(root, r);
         size++;
@@ -61,29 +72,55 @@ public class OrderedDictionary {
         return node;
     }
 
-    public void delete(DataKey k) {
-        root = delete(root, k);
+    public void remove(DataKey k) {
+        root = remove(root, k);
+        if (k.compareTo(smallest.data.key) == 0){
+            TreeNode node = getNodeByIndex(0);
+            smallest = node;
+            findSmallest();
+
+        } else if (k.compareTo(largest.data.key) == 0){
+            TreeNode node = getNodeByIndex(0);
+            largest = node;
+            findLargest();
+        }
+        // Ensure smallest or largest was not deleted
     }
 
-    private TreeNode delete(TreeNode node, DataKey k) {
+    private void findSmallest(){
+        findSmallest(getNodeByIndex(0));
+    }
+
+    private void findSmallest(TreeNode node){
+        if (node.data.key.height < smallest.data.key.height) {
+            //System.out.println(node.data.key.name);
+            smallest = node;
+        }
+        if (node.right != null) { findSmallest(node.right); }
+    }
+    private void findLargest(){
+        findLargest(getNodeByIndex(0));
+    }
+
+    private void findLargest(TreeNode node){
+        if (node.data.key.height > largest.data.key.height) {
+            //System.out.println(node.data.key.name);
+            largest = node;
+        }
+        if (node.right != null) { findLargest(node.right); }
+    }
+
+    private TreeNode remove(TreeNode node, DataKey k) {
         if (node == null) return null; // Item not found, do nothing
 
         if (k.compareTo(node.data.key) < 0) {
-            node.left = delete(node.left, k);
+            node.left = remove(node.left, k);
             node.leftSubtreeSize--;
         } else if (k.compareTo(node.data.key) > 0) {
-            node.right = delete(node.right, k);
+            node.right = remove(node.right, k);
         } else {
             // node with only one child or no child
             if ((node.left == null) || (node.right == null)) {
-
-                // clunky, but if deletion target is smallest or largest, null the stored node.
-                if (node.data.key.compareTo(smallest.data.key) == 0){
-                    smallest = null;
-                } else if (node.data.key.compareTo(largest.data.key) == 0){
-                    largest = null;
-                }
-                
                 TreeNode temp = null;
                 if (temp == node.left)
                     temp = node.right;
@@ -102,21 +139,20 @@ public class OrderedDictionary {
                 // node with two children
                 node.data = minValue(node.right);
 
-                node.right = delete(node.right, node.data.key);
+                node.right = remove(node.right, node.data.key);
             }
         }
 
-        // Ensure smallest or largest was not deleted
-        if (node != null && (smallest == null || node.data.key.height < smallest.data.key.height)) {
-            smallest = node;
-            // Probably need to search dict, doesn't necessarily find the smallest in the entire set right now.
-        }
-
-        if (node != null && (largest == null || node.data.key.height > largest.data.key.height)) {
-            largest = node;
-        }
-
         return node;
+    }
+
+    private TreeNode successor(DataKey k){
+        TreeNode node = findNode(k);
+        return (node.right == null) ? null : node.right;
+    }
+    private TreeNode predecessor(DataKey k){
+        TreeNode node = findNode(k);
+        return (node.left == null) ? null : node.left;
     }
 
     private ObjectRecord minValue(TreeNode node) {
@@ -147,12 +183,30 @@ public class OrderedDictionary {
         return getByIndex(node.right, index - node.leftSubtreeSize - 1);
     }
 
+    private TreeNode getNodeByIndex(int index) {
+        return getNodeByIndex(root, index);
+    }
+    private TreeNode getNodeByIndex(TreeNode node, int index) {
+        if (node == null) return null;
+
+        if (node.leftSubtreeSize == index) return node;
+        if (index < node.leftSubtreeSize) return getNodeByIndex(node.left, index);
+        return getNodeByIndex(node.right, index - node.leftSubtreeSize - 1);
+    }
+
     public ObjectRecord getSmallest() {
         return (smallest == null) ? null : smallest.data;
     }
 
     public ObjectRecord getLargest() {
         return (largest == null) ? null : largest.data;
+    }
+
+    public int getSmallestIndex(){
+        return (largest == null) ? null : smallest.leftSubtreeSize;
+    }
+    public int getLargestIndex(){
+        return (largest == null) ? null : largest.leftSubtreeSize;
     }
 
     public int size() {

--- a/src/main/java/com/example/pokedex/OrderedDictionary.java
+++ b/src/main/java/com/example/pokedex/OrderedDictionary.java
@@ -76,6 +76,14 @@ public class OrderedDictionary {
         } else {
             // node with only one child or no child
             if ((node.left == null) || (node.right == null)) {
+
+                // clunky, but if deletion target is smallest or largest, null the stored node.
+                if (node.data.key.compareTo(smallest.data.key) == 0){
+                    smallest = null;
+                } else if (node.data.key.compareTo(largest.data.key) == 0){
+                    largest = null;
+                }
+                
                 TreeNode temp = null;
                 if (temp == node.left)
                     temp = node.right;
@@ -101,6 +109,7 @@ public class OrderedDictionary {
         // Ensure smallest or largest was not deleted
         if (node != null && (smallest == null || node.data.key.height < smallest.data.key.height)) {
             smallest = node;
+            // Probably need to search dict, doesn't necessarily find the smallest in the entire set right now.
         }
 
         if (node != null && (largest == null || node.data.key.height > largest.data.key.height)) {

--- a/src/main/java/com/example/pokedex/OrderedDictionary.java
+++ b/src/main/java/com/example/pokedex/OrderedDictionary.java
@@ -19,11 +19,8 @@ public class OrderedDictionary {
     private TreeNode root;
 
     private TreeNode smallest = null;
-    private int smallInd = 0;
 
     private TreeNode largest = null;
-
-    private int largeInd = 0;
 
     public ObjectRecord find(DataKey k) {
         return find(root, k);
@@ -91,6 +88,7 @@ public class OrderedDictionary {
         }
     }
 
+    // Recursive scan for smallest height
     private void findSmallest(){
         findSmallest(getNodeByIndex(0));
     }
@@ -101,6 +99,8 @@ public class OrderedDictionary {
         }
         if (node.right != null) { findSmallest(node.right); }
     }
+
+    // Recursive scan for largest height
     private void findLargest(){
         findLargest(getNodeByIndex(0));
     }
@@ -170,7 +170,6 @@ public class OrderedDictionary {
         root = null;
         size = 0;
     }
-
 
 
     public ObjectRecord getByIndex(int index) {

--- a/src/main/java/com/example/pokedex/PokemonApp.java
+++ b/src/main/java/com/example/pokedex/PokemonApp.java
@@ -486,8 +486,8 @@ public class PokemonApp extends Application {
         DataKey pokemonKey = new DataKey(pokemon.getName(), pokemon.getHeight());
 
         // Delete the Pokémon from both OrderedDictionary instances
-        currentPokemons.delete(pokemonKey);
-        PokemonData.data.delete(pokemonKey);
+        currentPokemons.remove(pokemonKey);
+        PokemonData.data.remove(pokemonKey);
 
         pokemon = null;
 

--- a/src/main/java/com/example/pokedex/PokemonApp.java
+++ b/src/main/java/com/example/pokedex/PokemonApp.java
@@ -260,6 +260,9 @@ public class PokemonApp extends Application {
 
         currentIndex = 0;
         showPokemonAtIndex(currentIndex);
+        
+        //Enable buttons if previous search had no match
+        toggleButtons(false);
     }
 
 


### PR DESCRIPTION
Probably not very optimal, but smallest/largest deletion now handled all the way through.
Small fix for failed search -> reload -> toggle UI
refactored 'delete()' -> 'remove()' 
preliminary definitions for methods in rubric: 'successor()', 'predecessor()' , smallest(), largest(), isEmpty()